### PR TITLE
Replaces / with : to follow uri convention

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -9,7 +9,7 @@ function walk() {
 
 function convertSpotifyLinks(node) {
   var initialAttribute = node.getAttribute("href");
-  var replacedAttribute = initialAttribute.replace(/(https:\/\/open.spotify.com\/)/i, "spotify:");
+  var replacedAttribute = initialAttribute.replace(/(https:\/\/open.spotify.com\/)/i, "spotify:").replace("/", ":");
 
   if (replacedAttribute !== initialAttribute) {
     node.setAttribute("href", replacedAttribute);


### PR DESCRIPTION
Spotify URIs with / don't work when pasted into the Spotify search bar ✌️ 